### PR TITLE
Fix TensorFlow WASM path and enable iOS orientation prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs-backend-wasm@3.21.0/dist/tf-backend-wasm.min.js"></script>
   <script>
     // Tell TensorFlow where the WASM binaries live and switch backend.
-    tf.wasm.setWasmPaths('/js/');
+    tf.wasm.setWasmPaths('./js/');
     // Store the promise so we can wait before starting MindAR
     window.tfReady = tf.setBackend('wasm').then(() => tf.ready());
   </script>
   <!-- MindAR scripts -->
-  <script src="/js/mindar-image-aframe.prod.js" defer></script>
+  <script src="./js/mindar-image-aframe.prod.js" defer></script>
   <script>
     // Wait until TensorFlow WASM backend is ready before letting MindAR initialise.
     window.addEventListener('DOMContentLoaded', async () => {
@@ -34,7 +34,7 @@
          embedded 
          renderer="antialias: true; precision: medium; colorManagement: true; physicallyCorrectLights: true"
          vr-mode-ui="enabled: false"
-         device-orientation-permission-ui="enabled: false">
+         device-orientation-permission-ui="enabled: true">
   <a-assets>
     <a-asset-item id="muralModel" src="assets/test_fun_shape_animated.glb"></a-asset-item>
   </a-assets>

--- a/public/index.html.backup
+++ b/public/index.html.backup
@@ -19,8 +19,8 @@
         console.log('Initializing TensorFlow.js...');
         
         // Set WASM paths to our local js directory
-        tf.wasm.setWasmPaths('/js/');
-        console.log('WASM paths set to /js/');
+        tf.wasm.setWasmPaths('./js/');
+        console.log('WASM paths set to ./js/');
         
         // Set backend to WASM
         await tf.setBackend('wasm');
@@ -112,7 +112,7 @@
          embedded 
          renderer="antialias: true; precision: medium; colorManagement: true; physicallyCorrectLights: true"
          vr-mode-ui="enabled: false"
-         device-orientation-permission-ui="enabled: false">
+         device-orientation-permission-ui="enabled: true">
   <a-assets>
     <a-asset-item id="muralModel" src="assets/test_fun_shape_animated.glb"></a-asset-item>
   </a-assets>


### PR DESCRIPTION
## Summary
- load TensorFlow WASM binaries from relative `./js` directory
- reference MindAR script with a relative path
- show orientation permission prompt on iOS by enabling the device-orientation UI

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689cbf899b90832592098e60e3d32455